### PR TITLE
(fix) : CORS error for dev

### DIFF
--- a/AI/app/__init__.py
+++ b/AI/app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, request
 from data.training.train import Automatic_train_Model
 from watchdog.observers import Observer
 from utils.config import UNPROCESSED_FILES_DIR
@@ -18,6 +18,11 @@ def initialize_app():
     allowed_origins = os.getenv("ALLOWED_ORIGINS", "https://preppal.club").split(",")
     CORS(app, resources={r"/*": {"origins": allowed_origins}})
 
+    @app.before_request
+    def handle_preflight():
+        if request.method == 'OPTIONS':
+            return '', 200 
+        
     from app.routes.questions import api
     app.register_blueprint(api, url_prefix="/")
 

--- a/AI/app/__init__.py
+++ b/AI/app/__init__.py
@@ -6,12 +6,17 @@ from data.training.customize_spacy_train import Custom_Train_Spacy_Model
 import os
 import atexit
 from data.training.customize_spacy_train import Custom_Train_Spacy_Model
+from flask_cors import CORS
+from dotenv import load_dotenv
 
+load_dotenv()
 spacy_trainer = Custom_Train_Spacy_Model()
 event_handler = Automatic_train_Model()
 
 def initialize_app():
     app = Flask(__name__)
+    allowed_origins = os.getenv("ALLOWED_ORIGINS", "https://preppal.club").split(",")
+    CORS(app, resources={r"/*": {"origins": allowed_origins}})
 
     from app.routes.questions import api
     app.register_blueprint(api, url_prefix="/")

--- a/AI/app/routes/questions.py
+++ b/AI/app/routes/questions.py
@@ -10,6 +10,9 @@ refine_prompt = Refine_Prompt()
 api = Blueprint("api", __name__)
 @api.route('/get_questions', methods=['POST'])
 def get_questions_route():
+    if request.method == 'OPTIONS':
+        return '', 200
+    
     data = request.json
     prompt = data.get("prompt", "")
     

--- a/AI/app/routes/questions.py
+++ b/AI/app/routes/questions.py
@@ -10,8 +10,6 @@ refine_prompt = Refine_Prompt()
 api = Blueprint("api", __name__)
 @api.route('/get_questions', methods=['POST'])
 def get_questions_route():
-    if request.method == 'OPTIONS':
-        return '', 200
     
     data = request.json
     prompt = data.get("prompt", "")

--- a/AI/utils/prompt_template.py
+++ b/AI/utils/prompt_template.py
@@ -6,7 +6,7 @@ Extract the following details for **each subject mentioned** in the user input:
 1. **Subject**: Academic subject.
 2. **Topic**: Corresponding Academic topic name.
 3. **Chapter**: Corresponding chapter name.
-4. **Class**: Grade 5,6 or standard.
+4. **Class**: Grades or standard.
 5. **Difficulty**: The difficulty level (Easy, Medium, Hard). If not specified, default to "Easy".
 6. **NumberOfQuestions**: The total count of questions requested. If not specified, default to `20`.
 7. **QuestionType**: The type of questions (Single Choice, Subjective, Multiple Choice). if not specified default to `Multiple choice`


### PR DESCRIPTION
# Pull Request for CORS error

## Description
In this PR, I've addressed the issue of the CORS not being handled from the `/get_question`s API. It needs to be inserted through the .env file in the comma-separated format(default- https://preppal.club):

-  ALLOWED_ORIGINS=http://localhost:3000,https://staging/prepal.club,https://production.preppal.club

## Root Cause
-  The CORS  was not configured to allow requests from the necessary domains for dev and production.

## Breaking Changes
NA

## Additional Comments
NA

## Screenshots 
NA
