### PR TITLE
(enhancement) : Parsed Json by Request Id

### DIFF
--- a/AI/app/services/pdf_processing_service.py
+++ b/AI/app/services/pdf_processing_service.py
@@ -13,7 +13,7 @@ class PDFProcessor:
         return text
 
     def generate_notes(self, pdf_path, offset_start, table_of_contents):
-        notes = {}
+        chapters = []
 
         for chapter in table_of_contents["table_of_contents"]:
             chapter_name = chapter["title"]
@@ -35,10 +35,11 @@ class PDFProcessor:
                 topic_summary = self.summarizer.summarize(topic_text)
 
                 chapter_notes["topics"].append({
-                    "name": topic_name,
-                    "content_highlights": topic_summary
+                    "topic_name": topic_name,
+                    "topic_notes": topic_summary
                 })
 
-            notes[chapter_name] = chapter_notes
+            chapters.append(chapter_notes)
 
-        return notes
+
+        return chapters

--- a/AI/utils/chorma_response_to_json.py
+++ b/AI/utils/chorma_response_to_json.py
@@ -12,10 +12,10 @@ class ChromaResponseToJson:
 
         return {
             "request_id": request_id,
-            "pdf_link": metadata.get("notes_path", ''),
+            "notes__path": metadata.get("notes_path", ''),
             "status": metadata.get("status", "pending"),
             "title": Path(metadata.get('file_path')).name,
-            "file_path": metadata.get('file_path', ''),
+            "upload_pdf_path": metadata.get('file_path', ''),
             "table_of_contents": table_of_contents_metadata
         }
 


### PR DESCRIPTION
# Pull Request for Parsed Json in Response

## Description
`/records/<request_id> `endpoint to return the actual content of the notes in the response, parsed from the JSON file, instead of just providing the file path

## Corner Cases
-  If the record's status is not "completed", no notes will be returned, and the response will indicate the current status (either "processing" or "pending").
-  If the notes file is missing or corrupted, an error message will be returned instead of the notes data.


## Breaking Changes
NA

## Additional Comments
NA

## Screenshots 
![image](https://github.com/user-attachments/assets/e625b697-707c-4adf-8557-9be4fdb563c1)