### PR TITLE
(fix): Deleting Entry with the associated notes and PDF

### DIFF
--- a/AI/app/routes/notes.py
+++ b/AI/app/routes/notes.py
@@ -64,7 +64,7 @@ class Routes:
         if status in ["processing", "pending"]:
             return jsonify({"status": status, "message": "Record is still being processed"}), 202
 
-        notes_path = formatted_records.get("notes__path")
+        notes_path = formatted_records.get("notes_path")
         chapters = []
 
         if status == "completed" and notes_path and Path(notes_path).is_file():
@@ -84,6 +84,10 @@ class Routes:
         if not record:
             return jsonify({"error": "Request ID not found"}), 404
         
-        notes_service.db.delete_entry(request_id)
-        return jsonify({"message": "Record deleted successfully"}), 200
+        try:
+            notes_service.db.delete_entry(request_id)
+            return jsonify({"message": "Record deleted successfully"}), 200
+
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 404
 

--- a/AI/utils/chorma_response_to_json.py
+++ b/AI/utils/chorma_response_to_json.py
@@ -12,7 +12,7 @@ class ChromaResponseToJson:
 
         return {
             "request_id": request_id,
-            "notes__path": metadata.get("notes_path", ''),
+            "notes_path": metadata.get("notes_path", ''),
             "status": metadata.get("status", "pending"),
             "title": Path(metadata.get('file_path')).name,
             "upload_pdf_path": metadata.get('file_path', ''),

--- a/AI/utils/chroma_storage.py
+++ b/AI/utils/chroma_storage.py
@@ -47,7 +47,7 @@ class ChromaStorage:
     def delete_entry(self, request_id):
         try:
             entry = self.collection.get(ids=[request_id])
-            print(entry)
+
             if not entry or request_id not in entry['ids']:
                 raise ValueError(f"No entry found with request_id {request_id}. Cannot delete.")
             

--- a/AI/utils/chroma_storage.py
+++ b/AI/utils/chroma_storage.py
@@ -1,37 +1,23 @@
 import os
-import chromadb
+from utils.config import NOTES_CHROMA_DIR
 from chromadb.config import Settings
-import sqlite3
-
+from utils.initialize_ChromaDb import ChromaDBInitializer
 class ChromaStorage:
-    def __init__(self, persist_directory="data/chroma"):
-        self.db_path = f"{persist_directory}/chromadb.db"
+    def __init__(self, persist_directory=NOTES_CHROMA_DIR):
+        self.db_path = f"{persist_directory}"
+        self.collection = ChromaDBInitializer.get_or_create_collection("notes")
         
         if not os.path.exists(self.db_path):
             print(f"Database not found at {self.db_path}. Initializing a new one.")
         
+    def add_entry(self, request_id, status, file_path, reference_context, document=""):
         try:
-            self.client = chromadb.Client(Settings(persist_directory=persist_directory))
-            self.collection = self.client.get_or_create_collection(name="notes")
-        except sqlite3.OperationalError as e:
-            if "no such table: collections" in str(e):
-                print("Collections table missing. Recreating the database...")
-                os.remove(self.db_path)
-                self.client = chromadb.Client(Settings(persist_directory=persist_directory))
-                self.collection = self.client.get_or_create_collection(name="notes")
-            else:
-                raise e
-
-    def add_entry(self, request_id, status, file_path, document=""):
-        
-        print(request_id,status,file_path)
-        try:
-            result=self.collection.add(
+            result = self.collection.add(
                 ids=[request_id],
-                metadatas=[{"status": status, "file_path": file_path}],
+                metadatas=[{"status": status, "file_path": file_path, "reference_context": reference_context}],
                 documents=[document],
             )
-            print("entry",result)
+            print(f"Entry added: {result}")
         except Exception as e:
             print(f"Error adding entry for {request_id}: {e}")
             raise
@@ -60,7 +46,28 @@ class ChromaStorage:
 
     def delete_entry(self, request_id):
         try:
+            entry = self.collection.get(ids=[request_id])
+            print(entry)
+            if not entry or request_id not in entry['ids']:
+                raise ValueError(f"No entry found with request_id {request_id}. Cannot delete.")
+            
+            metadata = entry['metadatas'][0]
+            notes_path = metadata.get('notes_path')
+            pdf_path = metadata.get('file_path')
+
+            for file_path in [notes_path, pdf_path]:
+                if file_path and os.path.exists(file_path):
+                    try:
+                        os.remove(file_path)
+                        print(f"Deleted file at {file_path}")
+                    except Exception as e:
+                        print(f"Error deleting file at {file_path}: {e}")
+                else:
+                    print(f"File at {file_path} does not exist.")
+
             self.collection.delete(ids=[request_id])
+            print(f"Entry deleted for {request_id}")
+
         except Exception as e:
             print(f"Error deleting entry for {request_id}: {e}")
             raise

--- a/AI/utils/config.py
+++ b/AI/utils/config.py
@@ -7,6 +7,7 @@ GROQ_API_KEY =os.getenv("GROQ_API_KEY")
 PROCESSED_FILES_DIR="data/processed_questions/"
 UNPROCESSED_FILES_DIR="data/unprocessed_questions"
 CHROMA_DB_DIR = "data/chroma_db"
+NOTES_CHROMA_DIR="data/chroma"
 SPACY_CUSTOM_TRAINED_DIR="data/spacy_custom_trained"
 SPACY_CUSTOM_MODEL_NAME="custom_spacy_model"
 ABBREVIATION_DATA_DIR="data/abbreviation_data"


### PR DESCRIPTION
# Pull Request for Deleting Entry with the associated notes and PDF

## Description
This PR ensures that uploaded files and generated notes associated with a given request_id are deleted properly and it removes the corresponding records from ChromaDB, helping free up storage space.

## Impact
-  Frees up storage by deleting records from ChromaDB.

## Corner Cases
-  Verifying that only records matching the request_id are deleted.
-  Handled ChromaDB behavior where collections are continuously recreated and deleted after each server restart.

## Breaking Changes
NA

## Additional Comments
- NA

## Screenshots 
NA
