### PR TITLE
(refactor): Different Folder for collecting notes and questions embedding

### DIFF
--- a/AI/requirements.txt
+++ b/AI/requirements.txt
@@ -3,7 +3,7 @@ langchain-core==0.3.21
 langchain-groq==0.2.1
 sentence-transformers==3.3.1
 pandas== 2.2.3
-chromadb==0.5.0
+chromadb
 numpy==1.26.4
 python-dotenv==1.0.1
 accelerate>=1.1.1

--- a/AI/utils/chroma_storage.py
+++ b/AI/utils/chroma_storage.py
@@ -5,7 +5,7 @@ from utils.initialize_ChromaDb import ChromaDBInitializer
 class ChromaStorage:
     def __init__(self, persist_directory=NOTES_CHROMA_DIR):
         self.db_path = f"{persist_directory}"
-        self.collection = ChromaDBInitializer.get_or_create_collection("notes")
+        self.collection = ChromaDBInitializer.get_or_create_collection("notes",persist_directory=persist_directory)
         
         if not os.path.exists(self.db_path):
             print(f"Database not found at {self.db_path}. Initializing a new one.")
@@ -66,7 +66,6 @@ class ChromaStorage:
                     print(f"File at {file_path} does not exist.")
 
             self.collection.delete(ids=[request_id])
-            print(f"Entry deleted for {request_id}")
 
         except Exception as e:
             print(f"Error deleting entry for {request_id}: {e}")

--- a/AI/utils/initialize_ChromaDb.py
+++ b/AI/utils/initialize_ChromaDb.py
@@ -6,18 +6,21 @@ class ChromaDBInitializer:
     _chroma_client = None
     _embedding_function = None
     _model = None
+    _db_path = None
     
     @classmethod
-    def get_chroma_client(cls, safe_mode=True):
-        if cls._chroma_client is None:
+    def get_chroma_client(cls, persist_directory=CHROMA_DB_DIR, safe_mode=True):
+         if cls._chroma_client is None or cls._db_path != persist_directory:
             try:
-                cls._chroma_client = chromadb.PersistentClient(path=CHROMA_DB_DIR)
+                cls._chroma_client = chromadb.PersistentClient(path=persist_directory)
+                cls._db_path = persist_directory
             except Exception as e:
                 if safe_mode:
                     cls._chroma_client = chromadb.Client()
+                    cls._db_path = persist_directory
                 else:
                     raise e
-        return cls._chroma_client
+         return cls._chroma_client
 
     @classmethod
     def get_embedding_function(cls):
@@ -32,7 +35,7 @@ class ChromaDBInitializer:
         return cls._model
 
     @classmethod
-    def get_or_create_collection(cls,collection_name):
-        chroma_client = cls.get_chroma_client()
+    def get_or_create_collection(cls, collection_name, persist_directory=CHROMA_DB_DIR):
+        chroma_client = cls.get_chroma_client(persist_directory=persist_directory)
         embedding_function = cls.get_embedding_function()
-        return chroma_client.get_or_create_collection(name=collection_name,embedding_function=embedding_function)
+        return chroma_client.get_or_create_collection(name=collection_name, embedding_function=embedding_function)


### PR DESCRIPTION
# Pull Request for Separate Folders for Notes and Questions Embeddings

## Description
-  We are having on the situation where collecting the notes and questions collection in the 1 folder leads to confusion for manual removal. 
-   notes and questions rely on different versions of the ChromaDB package, requiring to run on same version because we are running everything on 1 server

## Impact
-  Concern of the Separation for notes and question emebdding

## Changes
-  Upgraded to the latest version of ChromaDB, so can run both embeddings for notes and questions on a single server.
-  Fixed a bug where get_entry(request_id) would throw inconsistent errors if a record was missing in the collection.

## Breaking Changes
NA

## Additional Comments
- NA

## Screenshots 
NA
