### PR TITLE
(enhancement): Authentication for Notes

### DIFF
--- a/AI/app/middlewares/auth_middleware.py
+++ b/AI/app/middlewares/auth_middleware.py
@@ -1,0 +1,25 @@
+import requests
+from flask import request, jsonify
+import os
+
+AUTH_API_URL = os.getenv("AUTH_API_URL")
+
+def authorization_required():
+    if not (token := request.headers.get("Authorization")):
+        return jsonify({"error": "Unauthorized user"}), 403
+
+    try:
+        response = requests.get(AUTH_API_URL,headers={
+        "Authorization": token
+    })
+        if response.status_code == 200:
+            data = response.json()
+        
+            if data.get("success") and data.get("user"):
+                return None
+            else:
+                return jsonify({"error": "Unauthorized user"}), 403
+        else:
+            return jsonify({"error": "Authorization service error"}), 403
+    except Exception as e:
+        return jsonify({"error": "Authorization check failed"}), 403

--- a/AI/app/routes/notes.py
+++ b/AI/app/routes/notes.py
@@ -5,8 +5,11 @@ from app.services.notes_service import NotesService
 from utils.config import Config
 from pathlib import Path
 from utils.chorma_response_to_json import ChromaResponseToJson
+from app.middlewares.auth_middleware import authorization_required
 
 notes = Blueprint("notes", __name__)
+
+notes.before_request(authorization_required)
 
 @notes.route("/upload", methods=["POST"])
 def upload_pdf():


### PR DESCRIPTION
# Pull Request for Authentication for Notes

## Description
-  We are allowing anyone to use the notes generation with AI model which is expensive task, need restrict access to authorized users to prevent misuse 

## Changes
-   Added a middleware to validate authorized users before allowing access to the Notes generation API.
-   Integrated a call to an external API, of another server cause a `delay of the 700ms`


## Breaking Changes
NA

## Additional Comments
- NA

## Screenshots 
NA
